### PR TITLE
Upgrade to use NodeJS 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ outputs:
   status:
     description: "The Success/Failure of the action"
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"


### PR DESCRIPTION
NodeJS 12 is being [deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) soon. I have not tested this change but going off of this similar PR to upgrade https://github.com/AkhileshNS/heroku-deploy/pull/151